### PR TITLE
Fix code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -29,7 +29,6 @@ export default async function middleware(request: NextRequest) {
     request.nextUrl.pathname.startsWith('/sb-')
   ) {
     const newPath = request.nextUrl.pathname
-      .replace('/storybook/', '/storybook/')
       .replace('/sb-', '/storybook/sb-')
     return NextResponse.rewrite(new URL(newPath, request.url))
   }


### PR DESCRIPTION
Fixes [https://github.com/stewnight/legacy-grow-app/security/code-scanning/1](https://github.com/stewnight/legacy-grow-app/security/code-scanning/1)

To fix the problem, we need to remove the redundant replacement operation on line 32. This will ensure that the code is clean and free of unnecessary operations. The replacement of `'/storybook/'` with `'/storybook/'` does not change the string, so it can be safely removed without affecting the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
